### PR TITLE
Set background to white at naviation menu setup in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ dependencies {
   	protected void setupNavigationDrawerItem(ExtendableListView listView,
   			BaseNavigationDrawerListAdapter navigationListAdapter) {
   		// TODO add the navigation menu item here
+  		listView.setBackgroundColor(Color.WHITE);
   		navigationListAdapter.addItem("item 1", 
   		  DrawableUtil.getDrawable(this, R.drawable.ic_chat_grey600_24dp));
   		navigationListAdapter.addItem("item 2", 


### PR DESCRIPTION
Without background I thought I missied something or the app was buggy.
So setting the the background in the example is more clearer for
someone who new in this area.

Signed-off-by: Ádám Gólya adam.stork@gmail.com
